### PR TITLE
Added support for tetra smite enchantments

### DIFF
--- a/src/main/java/c4/consecration/integrations/ModuleTetra.java
+++ b/src/main/java/c4/consecration/integrations/ModuleTetra.java
@@ -38,6 +38,8 @@ public class ModuleTetra extends ModuleCompatibility {
                         if (UndeadHelper.isHolyMaterial(value)) {
                             return true;
                         }
+                    } else if (key.contains("enchantment/smite")) {
+                        return true;
                     }
                 }
             }


### PR DESCRIPTION
Tetra handles "enchantments" differently than vanilla, this should make it so that the player can damage undead using tetra items with the smite enchantment.