### PR TITLE
Updated config to allow for BW compat

### DIFF
--- a/src/main/java/c4/consecration/common/config/ConfigHandler.java
+++ b/src/main/java/c4/consecration/common/config/ConfigHandler.java
@@ -57,7 +57,7 @@ public class ConfigHandler {
         @Name("Holy Potions")
         @Comment("A list of potions that will be able to damage and smite undead")
         @RequiresMcRestart
-        public String[] holyPotions = new String[]{"consecration:holy_potion", "minecraft:instant_health"};
+        public String[] holyPotions = new String[]{"consecration:holy_potion", "minecraft:instant_health", "bewitchment:holy_water"};
 
         @Name("Holy Weapons")
         @Comment("A list of items that will be able to damage and smite undead")


### PR DESCRIPTION
Performing some minor compat on both ends. As it was requested by someone, I decided to look into it, and added compat on my end for what would already work, but the only compat you'd really need on your end is a slight config change, since all of the things I have that work on undead are already supported by your mod, or should already work due to how your mod is laid out (i.e there is a block that lights undead on fire in my mod, that should work with your mod by default).