### PR TITLE
Restore Tinkers' Construct Module functionality.

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -105,6 +105,7 @@ dependencies {
 
     compileOnly fg.deobf("curse.maven:tetra-289712:4618612")
     compileOnly fg.deobf("curse.maven:silentgear-297039:4585760")
+    compileOnly fg.deobf("curse.maven:tconstruct-74072:5358052")
 
     implementation fg.deobf(group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "${spectrelib_range}")
     jarJar fg.deobf(group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "${spectrelib_range}") {

--- a/forge/src/main/java/com/illusivesoulworks/consecration/ConsecrationForgeMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/consecration/ConsecrationForgeMod.java
@@ -25,6 +25,7 @@ import com.illusivesoulworks.consecration.common.config.ConsecrationConfig;
 import com.illusivesoulworks.consecration.common.impl.HolySources;
 import com.illusivesoulworks.consecration.common.integration.AbstractCompatibilityModule;
 import com.illusivesoulworks.consecration.common.integration.SilentGearModule;
+import com.illusivesoulworks.consecration.common.integration.TConstructModule;
 import com.illusivesoulworks.consecration.common.integration.TetraModule;
 import com.illusivesoulworks.consecration.common.integration.WerewolvesModule;
 import com.illusivesoulworks.consecration.common.network.ConsecrationNetwork;
@@ -72,6 +73,7 @@ public class ConsecrationForgeMod {
     MODULES.put("tetra", TetraModule.class);
     MODULES.put("werewolves", WerewolvesModule.class);
     MODULES.put("silentgear", SilentGearModule.class);
+    MODULES.put("tconstruct", TConstructModule.class);
   }
 
   public ConsecrationForgeMod() {

--- a/forge/src/main/java/com/illusivesoulworks/consecration/common/integration/TConstructModule.java
+++ b/forge/src/main/java/com/illusivesoulworks/consecration/common/integration/TConstructModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017-2023 Illusive Soulworks
+ *
+ * Consecration is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Consecration is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Consecration.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.illusivesoulworks.consecration.common.integration;
+
+import java.util.function.BiFunction;
+import com.illusivesoulworks.consecration.api.ConsecrationApi;
+import com.illusivesoulworks.consecration.api.ConsecrationImc;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.InterModComms;
+import slimeknights.tconstruct.library.materials.definition.MaterialVariantId;
+import slimeknights.tconstruct.library.tools.nbt.MaterialIdNBT;
+
+public class TConstructModule extends AbstractCompatibilityModule {
+
+  @Override
+  public void enqueueImc() {
+    InterModComms.sendTo("consecration", ConsecrationImc.HOLY_ATTACK.getId(),
+        () -> (BiFunction<LivingEntity, DamageSource, Boolean>) (livingEntity, damageSource) -> {
+          Entity source = damageSource.getDirectEntity();
+
+          if (source instanceof LivingEntity) {
+            ItemStack stack = ((LivingEntity) source).getMainHandItem();
+            MaterialIdNBT nbt = MaterialIdNBT.from(stack);
+            for (MaterialVariantId material : nbt.getMaterials()) {
+
+              if (ConsecrationApi.getInstance().isHolyMaterial(material.getId().getPath())) {
+                return true;
+              }
+            }
+          }
+          return false;
+        });
+  }
+}


### PR DESCRIPTION
Tinkers' Construct just released a stable 1.19.2 beta version.

Comment from changelog:
> First Beta release for 1.19.2. API should not break after this point, if it does feel free to open a bug report. This means it is fully safe for addons to update.

I don't think there is any risk of an API change anyhow, as this is identical to the 1.18.2 implementation. I just restored the file and updated it.

I tested with Tinkers' Construct 1.19.2-3.8.3.39 and Ice and Fire Dragons (for silver). It works perfectly.